### PR TITLE
地域カードコンポーネントの実装

### DIFF
--- a/src/components/AreaCard.tsx
+++ b/src/components/AreaCard.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+import icon from "../images/rightarrow_121279.svg";
+
+export const AreaCard: React.FC = () => {
+	return (
+		<button
+			type="button"
+			className="text-white bg-gray-700 w-96 h-16 px-5 py-2.5 inline-center text-center inline-flex items-center"
+		>
+			東京
+			<img className="w-5 h-5 ml-72" src={icon} />
+		</button>
+	);
+};

--- a/src/components/AreaCard.tsx
+++ b/src/components/AreaCard.tsx
@@ -3,13 +3,14 @@ import icon from "../images/rightarrow_121279.svg";
 
 type Props = {
 	name: string;
+	onClick: () => void;
 };
 
-export const AreaCard: React.FC<Props> = ({ name }) => {
+export const AreaCard: React.FC<Props> = ({ name, onClick }) => {
 	return (
 		<button
 			type="button"
-			onClick={() => console.log("クリックされたよ")}
+			onClick={onClick}
 			className="text-white bg-gray-700 w-96 h-16 px-5 py-2.5 inline-center text-center inline-flex items-center hover:bg-gray-400"
 		>
 			{name}

--- a/src/components/AreaCard.tsx
+++ b/src/components/AreaCard.tsx
@@ -1,13 +1,18 @@
 import React from "react";
 import icon from "../images/rightarrow_121279.svg";
 
-export const AreaCard: React.FC = () => {
+type Props = {
+	name: string;
+};
+
+export const AreaCard: React.FC<Props> = ({ name }) => {
 	return (
 		<button
 			type="button"
-			className="text-white bg-gray-700 w-96 h-16 px-5 py-2.5 inline-center text-center inline-flex items-center"
+			onClick={() => console.log("クリックされたよ")}
+			className="text-white bg-gray-700 w-96 h-16 px-5 py-2.5 inline-center text-center inline-flex items-center hover:bg-gray-400"
 		>
-			東京
+			{name}
 			<img className="w-5 h-5 ml-72" src={icon} />
 		</button>
 	);

--- a/src/images/rightarrow_121279.svg
+++ b/src/images/rightarrow_121279.svg
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='utf-8'?>
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 129 129" xmlns:xlink="http://www.w3.org/1999/xlink" enable-background="new 0 0 129 129">
+  <g>
+    <path d="m40.4,121.3c-0.8,0.8-1.8,1.2-2.9,1.2s-2.1-0.4-2.9-1.2c-1.6-1.6-1.6-4.2 0-5.8l51-51-51-51c-1.6-1.6-1.6-4.2 0-5.8 1.6-1.6 4.2-1.6 5.8,0l53.9,53.9c1.6,1.6 1.6,4.2 0,5.8l-53.9,53.9z"/>
+  </g>
+</svg>

--- a/src/stories/AreaCard.stories.tsx
+++ b/src/stories/AreaCard.stories.tsx
@@ -6,6 +6,11 @@ export default {
 	component: AreaCard,
 } as ComponentMeta<typeof AreaCard>;
 
-export const Template: ComponentStory<typeof AreaCard> = (args) => (
+const Template: ComponentStory<typeof AreaCard> = (args) => (
 	<AreaCard {...args} />
 );
+
+export const Default = Template.bind({});
+Default.args = {
+	name: "東京",
+};

--- a/src/stories/AreaCard.stories.tsx
+++ b/src/stories/AreaCard.stories.tsx
@@ -13,4 +13,7 @@ const Template: ComponentStory<typeof AreaCard> = (args) => (
 export const Default = Template.bind({});
 Default.args = {
 	name: "東京",
+	onClick: () => {
+		console.log("test");
+	},
 };

--- a/src/stories/AreaCard.stories.tsx
+++ b/src/stories/AreaCard.stories.tsx
@@ -1,0 +1,11 @@
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+import { AreaCard } from "../components/AreaCard";
+
+export default {
+	title: "Area Card",
+	component: AreaCard,
+} as ComponentMeta<typeof AreaCard>;
+
+export const Template: ComponentStory<typeof AreaCard> = (args) => (
+	<AreaCard {...args} />
+);


### PR DESCRIPTION
close #2
@taishi1116 
## 内容
- [ ] 地域の表示が出るカードのコンポーネントの実装
- [ ] 矢印の実装は、svgをインポートして実装
## 確認手順
- [ ] 手元にpullをしてnpm run storybookを実行
- [ ] 地域の名前の出るボタン形式の実装が出てくること