### PR TITLE
摂氏と華氏のボタンコンポーネントの実装

### DIFF
--- a/src/components/AreaCard.tsx
+++ b/src/components/AreaCard.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+import icon from "../images/rightarrow_121279.svg";
+
+export const AreaCard: React.FC = () => {
+	return (
+		<button
+			type="button"
+			className="text-white bg-gray-700 w-96 h-16 px-5 py-2.5 inline-center text-center inline-flex items-center"
+		>
+			東京
+			<img className="w-5 h-5 ml-72" src={icon} />
+		</button>
+	);
+};

--- a/src/components/Option.tsx
+++ b/src/components/Option.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+
+type Props = {
+	iconUrl: string;
+};
+
+export const Option: React.FC<Props> = ({ iconUrl }) => {
+	return (
+		<button className="w-10 h-10 focus:outline-none rounded-full bg-slate-400 hover:bg-slate-900">
+			<img className="m-2 w-5 h-5" src={iconUrl} />
+		</button>
+	);
+};

--- a/src/images/rightarrow_121279.svg
+++ b/src/images/rightarrow_121279.svg
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='utf-8'?>
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 129 129" xmlns:xlink="http://www.w3.org/1999/xlink" enable-background="new 0 0 129 129">
+  <g>
+    <path d="m40.4,121.3c-0.8,0.8-1.8,1.2-2.9,1.2s-2.1-0.4-2.9-1.2c-1.6-1.6-1.6-4.2 0-5.8l51-51-51-51c-1.6-1.6-1.6-4.2 0-5.8 1.6-1.6 4.2-1.6 5.8,0l53.9,53.9c1.6,1.6 1.6,4.2 0,5.8l-53.9,53.9z"/>
+  </g>
+</svg>

--- a/src/stories/AreaCard.stories.tsx
+++ b/src/stories/AreaCard.stories.tsx
@@ -1,0 +1,11 @@
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+import { AreaCard } from "../components/AreaCard";
+
+export default {
+	title: "Area Card",
+	component: AreaCard,
+} as ComponentMeta<typeof AreaCard>;
+
+export const Template: ComponentStory<typeof AreaCard> = (args) => (
+	<AreaCard {...args} />
+);

--- a/src/stories/Opiton.stories.tsx
+++ b/src/stories/Opiton.stories.tsx
@@ -1,0 +1,24 @@
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+import { Option } from "../components/Option";
+
+export default {
+	title: "Option",
+	component: Option,
+} as ComponentMeta<typeof Option>;
+
+const Template: ComponentStory<typeof Option> = (args) => (
+	<div>
+		<Option {...args} />
+	</div>
+);
+
+export const Fahrenheit = Template.bind({});
+Fahrenheit.args = {
+	iconUrl: "https://cdn-icons-png.flaticon.com/512/121/121769.png",
+};
+
+export const Celsius = Template.bind({});
+Celsius.args = {
+	iconUrl:
+		"https://cdn-icons.flaticon.com/png/512/796/premium/796066.png?token=exp=1654337642~hmac=b44db03f2a53ba7d2d2d3e20573bb9e7",
+};


### PR DESCRIPTION
close #9 
@taishi1116 
## 内容
- [ ] 摂氏と華氏のボタンの実装
- [ ] 今回摂氏と華氏のボタンには、ポインターを当てるとホバーするCSSを追加
- [ ] 画像は、オープンデータの画像を使用
- [ ] propsでiconUrlでコンポーネントに渡している
## 確認手順
- [ ] ローカルの方にpullし、npm run storybookを実行
- [ ] storybookに表示されて表示及びホバーのCSSが反応するか確認